### PR TITLE
Ingress handles any subdomains

### DIFF
--- a/blog/templates/ingress.yaml
+++ b/blog/templates/ingress.yaml
@@ -11,6 +11,7 @@ spec:
   tls:
   - hosts:
     - wachs.work
+    - "*.wachs.work"
     secretName: wachswork-cert
   rules:
   - host: wachs.work
@@ -23,3 +24,14 @@ spec:
             name: blog
             port:
               number: 80
+  - host: "*.wachs.work"
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: blog
+            port:
+              number: 80
+


### PR DESCRIPTION
Handles requests to `www.wachs.work`, and all other subdomains.

Good for websites that index the site at `www.wachs.work`. TLS certs also work with this.

Fixes #2 